### PR TITLE
fix: convert multi-line `mode` strings to tables before using vim.keymap

### DIFF
--- a/lua/visual.lua
+++ b/lua/visual.lua
@@ -85,7 +85,7 @@ function visual.disable()
 			if mode == " " then
 				mode = "v"
 			end
-			vim.keymap.set(mode, map.lhs, map.rhs, {
+			vim.keymap.set(utils.str_to_table(mode), map.lhs, map.rhs, {
 				noremap = map.noremap,
 				silent = map.silent,
 				nowait = map.nowait,

--- a/lua/visual/serendipity.lua
+++ b/lua/visual/serendipity.lua
@@ -145,7 +145,7 @@ function M.exit()
 			mode = "v"
 		end
 		vim.keymap.set(
-			mode,
+			utils.str_to_table(mode),
 			map.lhs,
 			map.rhs,
 			{ noremap = map.noremap, silent = map.silent, nowait = map.nowait, callback = map.callback, buffer = buf }

--- a/lua/visual/utils.lua
+++ b/lua/visual/utils.lua
@@ -137,13 +137,28 @@ function utils.play_keys(keys)
 	end
 end
 
+function utils.str_to_table(mode)
+  -- mode may be a table or a single-character or multi-character string
+  if type(mode) == "table" then
+    return mode
+  end
+
+  if #mode == 1 then
+    return { mode }
+  end
+
+  local t = {}
+  mode:gsub(".", function (c) table.insert(t, c) end)
+  return t
+end
+
 function utils.del_maps_if_start_lhs(mappings, lhs)
 	local ret = false
 	for _, mapping in ipairs(mappings) do
 		-- if mapping.lhs starts with lhs
 		if mapping.lhs:sub(1, #lhs) == lhs then
 			Vdbg("Deleting mapping " .. mapping.lhs)
-			vim.keymap.del(mapping.mode, mapping.lhs)
+			vim.keymap.del(utils.str_to_table(mapping.mode), mapping.lhs)
 			ret = true
 		end
 	end


### PR DESCRIPTION
plugins written in vimscript (e.g. [CamelCase](https://github.com/bkad/CamelCaseMotion/)) may use multi-character strings for setting a mode, like "nox", which won't work for `vim.keymap.del` or `vim.keymap.set`. (results in a "shortname too long" error). Instead, convert those strings to tables to match the expected argument type. Also convert single-character strings to tables for consistency.

----

I'm fairly new with Lua. Feel free to make changes if necessary.